### PR TITLE
Return {true, ...} or {false, ...} from add_nodes

### DIFF
--- a/examples/chronicled/src/chronicled_server.erl
+++ b/examples/chronicled/src/chronicled_server.erl
@@ -242,13 +242,12 @@ add_nodes(Nodes) ->
                     ?LOG_DEBUG("nodes ~p", [nodes()]),
                     Result = chronicle:add_voters(ToAdd),
                     ?LOG_DEBUG("Result of voter addition: ~p", [Result]),
-                    Message = case Result of
-                                  ok ->
-                                      <<"nodes added">>;
-                                  _ ->
-                                      <<"nodes could not be added">>
-                              end,
-                    {Result, Message};
+                    case Result of
+                        ok ->
+                            {true, <<"nodes added">>};
+                        _ ->
+                            {false, <<"nodes could not be added">>}
+                    end;
                 CantConnect ->
                     ?LOG_DEBUG("Can't connect to nodes: ~p", [CantConnect]),
                     {false, <<"can't connect to some nodes to be added">>}


### PR DESCRIPTION
The config/addnode REST API was incorrectly returning a 400 when
nodes were successfully added due to a bug in the add_nodes function.
This patch corrects the return value from that function.

Change-Id: I49a456f33e2da1eacec5e6cf8d0e64fd0040d5e3