### PR TITLE
Disable unused-command-line-argument warning

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -40,4 +40,4 @@
          {clean, {pc, clean}}]},
   {post, [{compile, escriptize}]}]}.
 {port_specs, [{"linux", "priv/sync_nif.so", ["c_src/sync_nif.c"]}]}.
-{port_env, [{"CFLAGS", "$CFLAGS -Wall -Werror -std=gnu99"}]}.
+{port_env, [{"CFLAGS", "$CFLAGS -Wall -Wno-unused-command-line-argument -Werror -std=gnu99"}]}.

--- a/rebar2.config
+++ b/rebar2.config
@@ -13,4 +13,4 @@
 {erl_first_files, ["src/dynamic_supervisor.erl"]}.
 
 {port_specs, [{"linux", "priv/sync_nif.so", ["c_src/sync_nif.c"]}]}.
-{port_env, [{"CFLAGS", "$CFLAGS -Wall -Werror -std=gnu99"}]}.
+{port_env, [{"CFLAGS", "$CFLAGS -Wall -Wno-unused-command-line-argument -Werror -std=gnu99"}]}.


### PR DESCRIPTION
When building under ASAN we're using clang-9 as the frontend
and it utilize the toolchain from gcc-10.2.0:

    CC="clang-9"
    CFLAGS="--gcc-toolchain=/opt/gcc-10.2.0 -Wl,-rpath,/opt/gcc-10.2.0/lib64"

Given that we enable _ALL_ warnings through -Wall and
all warnings are treated as errors compilation fails
due to unused command line options:

    clang: error: -Wl,-rpath,/opt/gcc-10.2.0/lib64: 'linker' input unused [-Werror,-Wunused-command-line-argument]
    ERROR: compile failed while processing /home/couchbase/jenkins/workspace/sigar.ASan-UBSan_master/ns_server/deps/chronicle: rebar_abort

To work around the problem this patch adds an exception for
unused command line arguments.