### PR TITLE
Add function to return default txn timeout

### DIFF
--- a/src/chronicle_kv.erl
+++ b/src/chronicle_kv.erl
@@ -40,6 +40,7 @@
 
 -export([txn/2, txn/3, ro_txn/2, ro_txn/3]).
 -export([txn_get/2, txn_get_many/2]).
+-export([get_txn_default_timeout/0]).
 
 %% callbacks
 -export([specs/2,
@@ -261,6 +262,10 @@ txn_get_many(Keys, Txn) ->
         {txn_slow, Map} ->
             txn_get_from_map_many(Keys, Map)
     end.
+
+-spec get_txn_default_timeout() -> pos_integer().
+get_txn_default_timeout() ->
+    ?DEFAULT_TIMEOUT.
 
 -spec txn(name(), txn_fun(txn_opaque())) -> txn_result().
 txn(Name, Fun) ->


### PR DESCRIPTION
This adds the get_txn_default_timeout/0 function which returns the default timeout for a chronicle transaction. This can be used by clients of chronicle transactions to determine higher level timeouts for multi step operations, of which a chronicle transaction is one step.

Even though chronicle transactions support specifying a timeout, knowing the default value allows clients to calculate an upper level timeout without having to know what the specific chronicle default is.