### PR TITLE
MB-57128 Add histogram for leader_request

### DIFF
--- a/src/chronicle_rsm.erl
+++ b/src/chronicle_rsm.erl
@@ -29,6 +29,7 @@
 -export([callback_mode/0,
          format_status/2, sanitize_event/2,
          init/1, handle_event/4, terminate/3]).
+-export([get_histo_name/0, get_histo_max/0, get_histo_unit/0]).
 
 -import(chronicle_utils, [call/2, call/3, call/4,
                           read_deadline/1, start_timeout/1]).
@@ -141,9 +142,11 @@ sync(Name, Timeout) ->
 
 leader_request(Name, Request, TRef) ->
     Deadline = read_deadline(TRef),
-    case call(?SERVER(Name),
-              {leader_request, Request, Deadline}, leader_request,
-              infinity) of
+    Result = ?TIME(<<"leader_request">>, {ok, _},
+                   call(?SERVER(Name),
+                        {leader_request, Request, Deadline}, leader_request,
+                        infinity)),
+    case Result of
         ok ->
             ok;
         {ok, Reply} ->
@@ -1597,3 +1600,12 @@ get_incarnation(RSMDir) ->
 
     ok = chronicle_utils:store_int_to_file(Path, Incarnation),
     Incarnation.
+
+get_histo_name() ->
+    <<"chronicle_rsm">>.
+
+get_histo_max() ->
+    15000.
+
+get_histo_unit() ->
+    millisecond.

--- a/src/chronicle_storage.erl
+++ b/src/chronicle_storage.erl
@@ -36,6 +36,7 @@
          get_term_for_committed_seqno/1, get_term_for_seqno/2,
          get_log/0, get_log/2, get_log_committed/2, get_log_entry/2,
          ensure_rsm_dir/1, snapshot_dir/1,
+         get_histo_name/0, get_histo_max/0, get_histo_unit/0,
          handle_event/2,
          map_append/2]).
 
@@ -53,33 +54,6 @@
 
 -define(RANGE_KEY, '$range').
 -define(SNAPSHOT_KEY, '$snapshot').
-
--define(HISTO_METRIC(Op), {<<"chronicle_disk_latency">>, [{op, Op}]}).
--define(HISTO_MAX, 5000).
--define(HISTO_UNIT, millisecond).
-
--define(TIME_OK(Op, StartTS),
-        begin
-            __EndTS = erlang:monotonic_time(?HISTO_UNIT),
-            __Diff = __EndTS - StartTS,
-            chronicle_stats:report_histo(
-              ?HISTO_METRIC(Op), ?HISTO_MAX, ?HISTO_UNIT, __Diff)
-        end).
-
--define(TIME(Op, Body), ?TIME(Op, ok, Body)).
--define(TIME(Op, OkPattern, Body),
-        begin
-            __StartTS = erlang:monotonic_time(?HISTO_UNIT),
-            __Result = Body,
-            case __Result of
-                OkPattern ->
-                    ?TIME_OK(Op, __StartTS);
-                _ ->
-                    ok
-            end,
-
-            __Result
-        end).
 
 -type meta_state() :: ?META_STATE_PROVISIONED
                     | ?META_STATE_NOT_PROVISIONED
@@ -1569,3 +1543,12 @@ delete_logs(Paths) ->
                       error({delete_log_failed, Path, Error})
               end
       end, Paths).
+
+get_histo_name() ->
+    <<"chronicle_disk_latency">>.
+
+get_histo_max() ->
+    5000.
+
+get_histo_unit() ->
+    millisecond.


### PR DESCRIPTION
The leader_request function is a key point for chronicle operations and having a histogram of latencies may be helpful.