### PR TITLE
MB-56843: Use newer jiffy version

### DIFF
--- a/examples/chronicled/rebar.config
+++ b/examples/chronicled/rebar.config
@@ -4,7 +4,7 @@
          {git, "https://github.com/ninenines/cowboy",
           {tag, "2.8.0"}}},
         {jiffy, {git, "git@github.com:davisp/jiffy.git",
-                 {tag, "1.0.5"}}}]}.
+                 {tag, "1.1.1"}}}]}.
 {shell, [
     {apps, [chronicled]}
 ]}.


### PR DESCRIPTION
... in order to fix chronicled erlang 25 compilation issue

It seems to fix the following compilation error to me. I am not 100% sure that this was the reason though. It probably needs some extra testing.

```
$ rebar3 as examples compile
...
escript: exception error: undefined function enc:main/1
--
in function  escript:run/2 (escript.erl, line 750)
in call from escript:start/1 (escript.erl, line 277)
in call from init:start_em/1
in call from init:do_boot/3

```
