### PR TITLE
MB-59611 chronicle_dump support to dump "guts"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 # Used when built as part of couchbase server only.
 
+if(NOT DEFINED REBAR_VERSION)
+  # Default to building with rebar2 (the old behaviour)
+  SET(REBAR_VERSION "rebar2")
+endif()
+
+IF (${REBAR_VERSION} STREQUAL "rebar2")
+  # Config override only needed for rebar2
+  SET (REBAR_OPTS -C "${CMAKE_CURRENT_SOURCE_DIR}/rebar2.config")
+ENDIF()
+
 IF (NOT DEFINED INST_LIBDIR)
   MESSAGE(FATAL_ERROR "INST_LIBDIR is not defined.")
 ENDIF ()
@@ -8,17 +18,19 @@ IF (NOT TARGET ns_realclean)
   MESSAGE(FATAL_ERROR "ns_realclean target does not exist.")
 ENDIF ()
 
-SET (REBAR_OPTS -C "${CMAKE_CURRENT_SOURCE_DIR}/rebar2.config")
-
 REBAR (TARGET chronicle REBAR_OPTS ${REBAR_OPTS} CLEAN_HOOK ns_realclean)
 REBAR (TARGET chronicle_dump REBAR_OPTS ${REBAR_OPTS}
-  COMMAND escriptize NOCLEAN DEPENDS chronicle)
+       COMMAND escriptize NOCLEAN DEPENDS chronicle)
 
 SET(INSTALL_DIR "${INST_LIBDIR}/chronicle")
 
-# This assumes that rebar2 is used.
-INSTALL (DIRECTORY ebin DESTINATION "${INSTALL_DIR}")
-INSTALL (PROGRAMS chronicle_dump DESTINATION bin)
+IF (${REBAR_VERSION} STREQUAL "rebar2")
+  INSTALL (DIRECTORY ebin DESTINATION "${INSTALL_DIR}")
+  INSTALL (PROGRAMS chronicle_dump DESTINATION bin)
+ELSE()
+  INSTALL (DIRECTORY _build/default/lib/chronicle/ebin DESTINATION "${INSTALL_DIR}")
+  INSTALL (PROGRAMS _build/default/bin/chronicle_dump DESTINATION bin)
+ENDIF()
 
 # priv/ only exists on Linux currently, so make this OPTIONAL
 INSTALL (DIRECTORY priv OPTIONAL DESTINATION "${INSTALL_DIR}")

--- a/scripts/chronicle_dump/chronicle_dump.erl
+++ b/scripts/chronicle_dump/chronicle_dump.erl
@@ -150,6 +150,51 @@ sanitize_opt(Value) ->
             {error, invalid_function}
     end.
 
+binarify_output_item(Binary) when is_binary(Binary) -> Binary;
+binarify_output_item(Atom) when is_atom(Atom) -> atom_to_binary(Atom, latin1);
+binarify_output_item(Int) when is_integer(Int) -> integer_to_list(Int);
+binarify_output_item(String) when is_list(String) -> String.
+
+dump_guts(Args) ->
+    {Path, _Options} = parse_args(Args, #{}),
+    Guts = dump_guts_inner(Path),
+    Items = [E || {K, V} <- Guts, E <- [K, V]],
+    ?fmt("~s", [[[binarify_output_item(Item) | <<0:8>>] || Item <- Items]]).
+
+dump_guts_inner(Path) ->
+    case chronicle_storage:read_rsm_snapshot(Path) of
+        {ok, Snapshot} ->
+            try
+                Props0 = chronicle_rsm:format_snapshot(Snapshot),
+                Props1 = proplists:get_value("RSM state", Props0),
+                {?RAW_TAG, Props} = Props1,
+
+                CompatVer = get_value(cluster_compat_version, Props),
+                BucketNames = get_value(bucket_names, Props),
+
+                [{cluster_compat_version,
+                  iolist_to_binary(io_lib:format("~p", [CompatVer]))},
+                 {bucket_names, string:join(BucketNames, ",")},
+                 {rebalance_type, get_value(rebalance_type, Props)}]
+            catch
+                T:E:Stacktrace ->
+                    ?error("Unexpected exception: ~p:~p. Stacktrace:~n"
+                           "~p",
+                           [T, E,
+                            chronicle_utils:sanitize_stacktrace(Stacktrace)])
+            end;
+        {error, Error} ->
+            ?error("Couldn't read snapshot '~s': ~w", [Path, Error])
+    end.
+
+get_value(Key, Props) ->
+    case proplists:get_value(Key, Props) of
+        {Value, _ChronicleMeta} ->
+            Value;
+        _ ->
+            undefined
+    end.
+
 dump_snapshots(Args) ->
     {Paths, Options} = parse_args(Args,
                                   #{raw => flag,
@@ -289,6 +334,7 @@ usage() ->
     ?error("Usage: ~s [COMMAND]", [escript:script_name()]),
     ?error("Commands:"),
     ?error("    snapshot [--raw] [--sanitize <Mod:Fun>] [FILE]..."),
+    ?error("    dumpguts [FILE]"),
     ?error("         log [--sanitize <Mod:Fun>] [FILE]..."),
     stop(?STATUS_FATAL).
 
@@ -344,6 +390,8 @@ main(Args) ->
                     dump_snapshots(RestArgs);
                 "log" ->
                     dump_logs(RestArgs);
+                "dumpguts" ->
+                    dump_guts(RestArgs);
                 _ ->
                     usage("unknown command '~s'", [Command])
             end;


### PR DESCRIPTION
The chronicle_dump script is enhanced to provide a "dumpguts" option for use by cbcollect_info. Currently it returns:

   * cluster_compat_version
   * list of bucket names
   * rebalance type