### PR TITLE
Add encryption-at-rest

### DIFF
--- a/src/chronicle.hrl
+++ b/src/chronicle.hrl
@@ -112,6 +112,8 @@
 
 -define(CHRONICLE_LOGGER, '$chronicle_logger').
 -define(CHRONICLE_STATS, '$chronicle_stats').
+-define(CHRONICLE_ENCRYPT, '$chronicle_encrypt').
+-define(CHRONICLE_DECRYPT, '$chronicle_decrypt').
 
 -define(LOG(Level, Fmt, Args),
         (persistent_term:get(?CHRONICLE_LOGGER))(
@@ -121,6 +123,9 @@
             module => ?MODULE,
             function => ?FUNCTION_NAME,
             arity => ?FUNCTION_ARITY})).
+
+-define(ENCRYPT(Data), (persistent_term:get(?CHRONICLE_ENCRYPT))(Data)).
+-define(DECRYPT(Data), (persistent_term:get(?CHRONICLE_DECRYPT))(Data)).
 
 -define(CHECK(Cond1, Cond2),
         case Cond1 of

--- a/src/chronicle_env.erl
+++ b/src/chronicle_env.erl
@@ -22,6 +22,7 @@
 
 %% For use by chronicle_dump.
 -export([setup_logger/0]).
+-export([setup_decrypt_function/1]).
 
 -ifdef(TEST).
 -export([set_env/2]).
@@ -39,7 +40,8 @@ setup() ->
     ?CHECK(check_data_dir(),
            setup_logger_filter(),
            setup_logger(),
-           setup_stats()
+           setup_stats(),
+           setup_encryption()
           ).
 
 check_data_dir() ->
@@ -106,6 +108,15 @@ setup_logger_filter() ->
 setup_stats() ->
     setup_function(stats_function, 1,
                    fun chronicle_stats:ignore_stats/1, ?CHRONICLE_STATS).
+
+setup_encryption() ->
+    setup_function(encrypt_function, 1, fun (Data) -> Data end,
+                   ?CHRONICLE_ENCRYPT),
+    setup_function(decrypt_function, 1, fun (Data) -> {ok, Data} end,
+                   ?CHRONICLE_DECRYPT).
+
+setup_decrypt_function(Fun) ->
+    persistent_term:put(?CHRONICLE_DECRYPT, Fun).
 
 -ifndef(TEST).
 

--- a/src/chronicle_log.erl
+++ b/src/chronicle_log.erl
@@ -217,7 +217,7 @@ encode_terms([Term|Terms], AccData, AccWritten, Fun) ->
     end.
 
 encode_term(Term, AccData) ->
-    TermBinary = term_to_binary(Term),
+    TermBinary = ?ENCRYPT(term_to_binary(Term)),
     Size = byte_size(TermBinary),
     true = (Size =< ?TERM_SIZE_MAX),
 
@@ -333,8 +333,13 @@ decode_entry_size(Data) ->
 decode_entry_term(Data, Size) ->
     case get_crc_data(Data, Size) of
         {ok, TermBinary, Consumed, NewData} ->
-            Term = binary_to_term(TermBinary),
-            {ok, Term, Consumed, NewData};
+            case ?DECRYPT(TermBinary) of
+                {ok, DecryptedTermBinary} ->
+                    Term = binary_to_term(DecryptedTermBinary),
+                    {ok, Term, Consumed, NewData};
+                {error, decrypt_error} ->
+                    {error, corrupt}
+            end;
         Error ->
             Error
     end.


### PR DESCRIPTION
Pass encrypt and decrypt callbacks via app env, and use them every time data is written or read.

Pass decrypt callback to chronicle_dump, so it can decrypt data.