### PR TITLE
MB-63122: Add artifacts declaration for chronicle_dump

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -41,3 +41,8 @@
   {post, [{compile, escriptize}]}]}.
 {port_specs, [{"linux", "priv/sync_nif.so", ["c_src/sync_nif.c"]}]}.
 {port_env, [{"CFLAGS", "$CFLAGS -Wall -Wno-unused-command-line-argument -Werror -std=gnu99"}]}.
+
+%% We need to define artifacts declarations to ensure that these files
+%% get built because rebar3 is only capable of detecting that beam
+%% files have been recompiled.
+{artifacts, ["{{profile_dir}}/bin/chronicle_dump"]}.


### PR DESCRIPTION
rebar3 is not capable of determining that this file needs to be rebuilt if the chronicle erlang code does not need to be rebuilt. The Server build requires that it exists, it's necessary for log collection, so we need to ensure that it is built.

We need to do this for priv/sync_nif.so too, but that's somewhat troublesome as we need to do that only for linux. We'll address that in a future change.